### PR TITLE
Improve trip rate prep

### DIFF
--- a/R/hts_find_var.R
+++ b/R/hts_find_var.R
@@ -39,7 +39,7 @@ hts_find_var = function(var,
   if (nrow(var_location) == 0) {
     msg = paste0("Variable ", var, " not found")
     similar_vars =
-      variable_list[
+      variables_dt[
         agrep(
           pattern = var,
           x = variable,

--- a/man/hts_prep_triprate.Rd
+++ b/man/hts_prep_triprate.Rd
@@ -14,6 +14,7 @@ hts_prep_triprate(
   remove_outliers = FALSE,
   threshold = 0.975,
   weighted = TRUE,
+  strataname = NULL,
   hts_data = list(hh = hh, person = person, day = day, trip = trip, vehicle = vehicle)
 )
 }
@@ -38,6 +39,8 @@ Default is TRUE.}
 \item{threshold}{Threshold to define outliers. Default is 0.975.}
 
 \item{weighted}{Whether the data is weighted. Default is TRUE.}
+
+\item{strataname}{Name of strata name to bring in. Default is NULL.}
 
 \item{hts_data}{List containing household, person, day, trip, and vehicle
 datasets in data.table format.}


### PR DESCRIPTION
## Summary

Corrects a codebook reference.
Enables strata and trip-level grouping variables (e.g. mode) for trip rate summaries.
