### PR TITLE
Restrict zero-fill expansion in trip/vmt rate prep to trip-level grouping vars

### DIFF
--- a/R/hts_prep_triprate.R
+++ b/R/hts_prep_triprate.R
@@ -191,12 +191,19 @@ hts_prep_triprate = function(summarize_by = NULL,
     # If one of the by-variables is in trip table, need to expand to
     # include all levels of the variable for every trip, and fill with zeros:
     if (trip_id %in% names(byvar_dt)) {
+      triprate_cast_vars = summarize_by[vapply(
+        summarize_by,
+        function(var_name) hts_find_var(var_name, data = hts_data, variables_dt = variables_dt) == trip_name,
+        logical(1)
+      )]
+      triprate_id_vars = unique(c(triprate_cols, setdiff(summarize_by, triprate_cast_vars)))
+
       # fill in with zeros for zero trips for a given level of xt_var using dcast:
       dcast_formula =
         paste0(
-          paste0(triprate_cols, collapse = " + "),
+          paste0(triprate_id_vars, collapse = " + "),
           " ~ ",
-          paste0(summarize_by, collapse = " + ")
+          paste0(triprate_cast_vars, collapse = " + ")
         )
       
       triprate_cast = dcast(triprate_dt,
@@ -215,18 +222,18 @@ hts_prep_triprate = function(summarize_by = NULL,
       # transform back to long format, with separate cols for weighted & unwt. trip rates:
       triprate_dt = data.table::melt(
         triprate_cast,
-        id.vars = triprate_cols,
+        id.vars = triprate_id_vars,
         value.name = "num_trips"
       )
       
       # Relabel xtab trip vars after melting:
-      if (length(summarize_by) > 1) {
-        triprate_dt[, c(summarize_by) := tstrsplit(variable, "_")]
+      if (length(triprate_cast_vars) > 1) {
+        triprate_dt[, c(triprate_cast_vars) := tstrsplit(variable, "_")]
         triprate_dt[, variable := NULL]
       }
       
-      if (length(summarize_by) == 1) {
-        setnames(triprate_dt, old = "variable", new = summarize_by)
+      if (length(triprate_cast_vars) == 1) {
+        setnames(triprate_dt, old = "variable", new = triprate_cast_vars)
       }
       
       triprate_dt = triprate_dt[]

--- a/R/hts_prep_vmtrate.R
+++ b/R/hts_prep_vmtrate.R
@@ -175,12 +175,19 @@ hts_prep_vmtrate = function(summarize_by = NULL,
     # If one of the by-variables is in trip table, need to expand to
     # include all levels of the variable for every trip, and fill with zeros:
     if (trip_id %in% names(byvar_dt)) {
+      vmtrate_cast_vars = summarize_by[vapply(
+        summarize_by,
+        function(var_name) hts_find_var(var_name, data = hts_data, variables_dt = variables_dt) == trip_name,
+        logical(1)
+      )]
+      vmtrate_id_vars = unique(c(vmtrate_cols, setdiff(summarize_by, vmtrate_cast_vars)))
+
       # fill in with zeros for zero trips for a given level of xt_var using dcast:
       dcast_formula =
         paste0(
-          paste0(vmtrate_cols, collapse = " + "),
+          paste0(vmtrate_id_vars, collapse = " + "),
           " ~ ",
-          paste0(summarize_by, collapse = " + ")
+          paste0(vmtrate_cast_vars, collapse = " + ")
         )
       
       vmtrate_cast = dcast(vmtrate_dt,
@@ -199,18 +206,18 @@ hts_prep_vmtrate = function(summarize_by = NULL,
       # transform back to long format, with separate cols for weighted & unwt. vmt rates:
       vmtrate_dt = data.table::melt(
         vmtrate_cast,
-        id.vars = vmtrate_cols,
+        id.vars = vmtrate_id_vars,
         value.name = "vmt"
       )
       
       # Relabel xtab trip vars after melting:
-      if (length(summarize_by) > 1) {
-        vmtrate_dt[, c(summarize_by) := tstrsplit(variable, "_")]
+      if (length(vmtrate_cast_vars) > 1) {
+        vmtrate_dt[, c(vmtrate_cast_vars) := tstrsplit(variable, "_")]
         vmtrate_dt[, variable := NULL]
       }
       
-      if (length(summarize_by) == 1) {
-        setnames(vmtrate_dt, old = "variable", new = summarize_by)
+      if (length(vmtrate_cast_vars) == 1) {
+        setnames(vmtrate_dt, old = "variable", new = vmtrate_cast_vars)
       }
       
       vmtrate_dt = vmtrate_dt[]


### PR DESCRIPTION
Higher-level fields remain id vars; prevents cross-year denominator inflation when using multi-year datasets.

Affects only R/hts_prep_triprate.R & R/hts_prep_vmtrate.R 